### PR TITLE
Fix wrong parameter type bug

### DIFF
--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -47,7 +47,7 @@ export class UsersResolver {
     @Parent() author: UserDocument,
     @Args('options', { nullable: true }) options: PaginationOptions,
   ) {
-    return await this.postsService.findPosts({ authorId: author.id }, options);
+    return await this.postsService.findPosts({ authorId: author._id }, options);
   }
 
   @Mutation(() => Boolean)


### PR DESCRIPTION
Pass `authorId` param as `ObjectId` type not `string` to the resolve field method (`findPosts`) of `UsersResolver` class.