### PR TITLE
Feature/delete posts from 2 collections in transaction session

### DIFF
--- a/src/posts/services/deletePost.ts
+++ b/src/posts/services/deletePost.ts
@@ -1,20 +1,36 @@
 import { Model, Types } from 'mongoose';
 import { Post } from '../schemas/post.schema';
 import { InternalServerErrorException } from '@nestjs/common';
+import createTransactionSession from '../../global/utils/createTransactionSession';
+import { UsersService } from '../../users/users.service';
 
 export default async function deletePost(
   postId: Types.ObjectId,
   authorId: Types.ObjectId,
 ) {
+  const session = await createTransactionSession.bind(this)();
   try {
     const PostModel = this.PostModel as Model<Post>;
-    const { acknowledged, deletedCount } = await PostModel.deleteOne({
-      _id: postId,
-      authorId,
-    });
+    const usersService = this.UsersService as UsersService;
+    const { acknowledged, deletedCount } = await PostModel.deleteOne(
+      { _id: postId, authorId },
+      { session },
+    );
 
-    return acknowledged && !!deletedCount;
+    if (acknowledged && !!deletedCount) {
+      const removingResult = await usersService.removePost(authorId, postId, {
+        session,
+      });
+      if (removingResult) {
+        await session.commitTransaction();
+        return true;
+      }
+    } else {
+      await session.abortTransaction();
+      return false;
+    }
   } catch {
+    await session.abortTransaction();
     throw new InternalServerErrorException();
   }
 }

--- a/src/users/services/index.ts
+++ b/src/users/services/index.ts
@@ -2,3 +2,4 @@ export { default as findUserById } from './findUserById';
 export { default as findUsers } from './findUsers';
 export { default as updateUserData } from './updateUserData';
 export { default as addPost } from './addPost';
+export { default as removePost } from './removePost';

--- a/src/users/services/removePost.ts
+++ b/src/users/services/removePost.ts
@@ -1,0 +1,17 @@
+import { ClientSession, Model, Types } from 'mongoose';
+import { User } from '../schemas/user.schema';
+
+export default async function removePost(
+  userId: Types.ObjectId,
+  postId: Types.ObjectId,
+  options?: { session?: ClientSession },
+) {
+  const UserModel = this.UserModel as Model<User>;
+  const { acknowledged, modifiedCount } = await UserModel.updateOne(
+    { _id: userId },
+    { $pull: { posts: postId } },
+    options,
+  );
+
+  return acknowledged && !!modifiedCount;
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { findUserById, findUsers, updateUserData, addPost } from './services';
+import {
+  findUserById,
+  findUsers,
+  updateUserData,
+  addPost,
+  removePost,
+} from './services';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { User } from './schemas/user.schema';
@@ -15,4 +21,6 @@ export class UsersService {
   updateUserData = updateUserData;
 
   addPost = addPost;
+
+  removePost = removePost;
 }


### PR DESCRIPTION
Handle deleting posts from two collections under transaction session in `deletePost` method of `UsersService` class