### PR TITLE
Create reusable vote schema and dto in global folder

### DIFF
--- a/src/global/dto/interfaces.ts
+++ b/src/global/dto/interfaces.ts
@@ -1,0 +1,12 @@
+import { Field, Int, InterfaceType } from '@nestjs/graphql';
+import { MongoObjectIdScalar } from './mongoObjectId.scalar';
+import { Types } from 'mongoose';
+
+@InterfaceType()
+export abstract class VoteInterface {
+  @Field(() => Int)
+  totalVotes: number;
+
+  @Field(() => [MongoObjectIdScalar])
+  voters: Types.ObjectId[];
+}

--- a/src/global/dto/vote.type.ts
+++ b/src/global/dto/vote.type.ts
@@ -1,0 +1,13 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { MongoObjectIdScalar } from './mongoObjectId.scalar';
+import { Types } from 'mongoose';
+import { VoteInterface } from './interfaces';
+
+@ObjectType({ implements: () => VoteInterface })
+export class VoteType {
+  @Field(() => Int)
+  totalVotes: number;
+
+  @Field(() => [MongoObjectIdScalar])
+  voters: Types.ObjectId[];
+}

--- a/src/global/schemas/vote.schema.ts
+++ b/src/global/schemas/vote.schema.ts
@@ -1,0 +1,12 @@
+import { Prop, Schema } from '@nestjs/mongoose';
+import { VoteInterface } from '../dto/interfaces';
+import { Types } from 'mongoose';
+
+@Schema({ versionKey: false, _id: false })
+export class VotesSchema implements VoteInterface {
+  @Prop({ required: true })
+  totalVotes: number;
+
+  @Prop({ type: [Types.ObjectId], required: true })
+  voters: Types.ObjectId[];
+}

--- a/src/posts/dto/post-data.type.ts
+++ b/src/posts/dto/post-data.type.ts
@@ -2,15 +2,7 @@ import { ObjectType, Field, Int } from '@nestjs/graphql';
 import { MongoObjectIdScalar } from '../../global/dto/mongoObjectId.scalar';
 import { Types } from 'mongoose';
 import { PostResourceInterface, PostThumbnailInterface } from '../interfaces';
-
-@ObjectType()
-class Votes {
-  @Field(() => Int)
-  totalVotes: number;
-
-  @Field(() => [MongoObjectIdScalar])
-  voters: Types.ObjectId[];
-}
+import { VoteType } from '../../global/dto/vote.type';
 
 @ObjectType({ implements: () => [PostThumbnailInterface] })
 class PostThumbnail implements PostThumbnailInterface {
@@ -52,11 +44,11 @@ export class Post {
   @Field(() => [String], { defaultValue: [] })
   tags: string[];
 
-  @Field(() => Votes)
-  upvotes: Votes;
+  @Field(() => VoteType)
+  upvotes: VoteType;
 
-  @Field(() => Votes)
-  downvotes: Votes;
+  @Field(() => VoteType)
+  downvotes: VoteType;
 
   @Field(() => [PostResource])
   resources: PostResource[];

--- a/src/posts/schemas/post.schema.ts
+++ b/src/posts/schemas/post.schema.ts
@@ -1,15 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Types } from 'mongoose';
 import { PostResourceInterface, PostThumbnailInterface } from '../interfaces';
-
-@Schema({ versionKey: false, _id: false })
-class Votes {
-  @Prop({ required: true })
-  totalVotes: number;
-
-  @Prop({ type: [Types.ObjectId], required: true })
-  voters: Types.ObjectId[];
-}
+import { VotesSchema } from '../../global/schemas/vote.schema';
 
 @Schema({ versionKey: false, _id: false })
 class Thumbnail implements PostThumbnailInterface {
@@ -50,10 +42,10 @@ export class Post {
   tags: string[];
 
   @Prop({ default: { totalVotes: 0, voters: [] } })
-  upvotes: Votes;
+  upvotes: VotesSchema;
 
   @Prop({ default: { totalVotes: 0, voters: [] } })
-  downvotes: Votes;
+  downvotes: VotesSchema;
 
   @Prop({ type: [Resource], default: [] })
   resources: Resource[];


### PR DESCRIPTION
Create reusable vote schema (`VotesSchema`) and vote data type or dto (`VoteType`) inside global folder to reuse them in wherever in the project.