### PR TITLE
Convert the scalar type of users bookmarks field to an array of `MongoObjectIdScalar`

### DIFF
--- a/src/users/dto/user-data.type.ts
+++ b/src/users/dto/user-data.type.ts
@@ -22,7 +22,7 @@ export class User {
   })
   role: string;
 
-  @Field(() => MongoObjectIdScalar, {
+  @Field(() => [MongoObjectIdScalar], {
     description: 'The posts that the user has saved them',
   })
   bookmarks: [Types.ObjectId];


### PR DESCRIPTION
Convert the scalar type of users bookmarks field to an array of `MongoObjectIdScalar` not a single `MongoObjectIdScalar`.