### PR TITLE
Add `commentsCount` property to post schema & post data DTO

### DIFF
--- a/src/posts/dto/post-data.type.ts
+++ b/src/posts/dto/post-data.type.ts
@@ -1,4 +1,4 @@
-import { ObjectType, Field, GraphQLTimestamp } from '@nestjs/graphql';
+import { ObjectType, Field, GraphQLTimestamp, Int } from '@nestjs/graphql';
 import { MongoObjectIdScalar } from '../../global/dto/mongoObjectId.scalar';
 import { Types } from 'mongoose';
 import { PostResourceInterface, PostThumbnailInterface } from '../interfaces';
@@ -55,4 +55,7 @@ export class Post {
 
   @Field(() => GraphQLTimestamp, { name: 'publishedAt' })
   createdAt: Date;
+
+  @Field(() => Int, { defaultValue: 0 })
+  commentsCount: number;
 }

--- a/src/posts/schemas/post.schema.ts
+++ b/src/posts/schemas/post.schema.ts
@@ -49,6 +49,9 @@ export class Post {
 
   @Prop({ type: [Resource], default: [] })
   resources: Resource[];
+
+  @Prop({ type: Number, default: 0 })
+  commentsCount: number;
 }
 
 export type PostDocument = HydratedDocument<Post>;

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -82,6 +82,7 @@ type Post {
   downvotes: VoteType!
   resources: [PostResource!]!
   publishedAt: Timestamp!
+  commentsCount: Int!
   author: User
   userVote: String
 }


### PR DESCRIPTION
Add `commentsCount` prop to `Post` schema in `posts/schemas/post.schema.ts` file.

Add `commentsCount` field to `Post` object type in `posts/dto/post-data.type.ts` file.