### PR TITLE
Add "tracking comments count of posts" feature

### DIFF
--- a/src/post-comments/posts-comments.module.ts
+++ b/src/post-comments/posts-comments.module.ts
@@ -6,6 +6,7 @@ import {
   PostsCommentsSchema,
 } from './schemas/posts-comments.schema';
 import { PostsCommentsResolver } from './posts-comments.resolver';
+import { PostsModule } from '../posts/posts.module';
 
 @Module({
   providers: [PostsCommentsService, PostsCommentsResolver],
@@ -13,6 +14,7 @@ import { PostsCommentsResolver } from './posts-comments.resolver';
     MongooseModule.forFeature([
       { name: PostsComments.name, schema: PostsCommentsSchema },
     ]),
+    PostsModule,
   ],
 })
 export class PostsCommentsModule {}

--- a/src/post-comments/posts-comments.service.ts
+++ b/src/post-comments/posts-comments.service.ts
@@ -9,12 +9,14 @@ import {
 import { Model } from 'mongoose';
 import { PostsComments } from './schemas/posts-comments.schema';
 import { InjectModel } from '@nestjs/mongoose';
+import { PostsService } from '../posts/posts.service';
 
 @Injectable()
 export class PostsCommentsService {
   constructor(
     @InjectModel(PostsComments.name)
     private PostCommentsModel: Model<PostsComments>,
+    private PostsService: PostsService,
   ) {}
 
   addCommentToPost = addCommentToPost;

--- a/src/post-comments/services/addCommentToPost.ts
+++ b/src/post-comments/services/addCommentToPost.ts
@@ -1,6 +1,8 @@
 import { Model, Types } from 'mongoose';
 import { PostsComments, PostComment } from '../schemas/posts-comments.schema';
 import { InternalServerErrorException } from '@nestjs/common';
+import createTransactionSession from '../../global/utils/createTransactionSession';
+import { PostsService } from '../../posts/posts.service';
 
 export default async function addCommentToPost(
   postId: Types.ObjectId,
@@ -9,6 +11,9 @@ export default async function addCommentToPost(
 ) {
   try {
     const PostCommentsModel = this.PostCommentsModel as Model<PostsComments>;
+    const PostsService = this.PostsService as PostsService;
+
+    const session = await createTransactionSession();
 
     const newComment = new PostComment();
     newComment.commenterId = userId;
@@ -19,16 +24,28 @@ export default async function addCommentToPost(
       await PostCommentsModel.updateOne(
         { _id: postId },
         { $push: { comments: newComment } },
+        { session },
       );
 
     if (!matchedCount) {
-      return await PostCommentsModel.create({
-        comments: [newComment],
-        _id: postId,
-      }).then(() => true);
+      return await PostCommentsModel.create(
+        {
+          comments: [newComment],
+          _id: postId,
+        },
+        { session },
+      ).then(() => true);
     }
 
-    return acknowledged && !!modifiedCount;
+    if (
+      acknowledged &&
+      !!modifiedCount &&
+      (await PostsService.incrementPostCommentsCount(postId, session))
+    ) {
+      return await session.commitTransaction().then(() => true);
+    } else {
+      await session.abortTransaction();
+    }
   } catch {
     throw new InternalServerErrorException();
   }


### PR DESCRIPTION
Use use `incrementPostCommentsCount` method of `PostsService` service to
increment the comments count of the post after adding a new comment.

Use `createTransactionSession` to create a session to update the two collections
(`postcomments` and `posts` ) together.
