### PR TITLE
Inject mongoose connection model to `postsCommentsService` class

### DIFF
--- a/src/post-comments/posts-comments.service.ts
+++ b/src/post-comments/posts-comments.service.ts
@@ -6,9 +6,9 @@ import {
   upvotePostComment,
   downvotePostComment,
 } from './services';
-import { Model } from 'mongoose';
+import { Connection, Model } from 'mongoose';
 import { PostsComments } from './schemas/posts-comments.schema';
-import { InjectModel } from '@nestjs/mongoose';
+import { InjectConnection, InjectModel } from '@nestjs/mongoose';
 import { PostsService } from '../posts/posts.service';
 
 @Injectable()
@@ -17,6 +17,7 @@ export class PostsCommentsService {
     @InjectModel(PostsComments.name)
     private PostCommentsModel: Model<PostsComments>,
     private PostsService: PostsService,
+    @InjectConnection() private connection: Connection,
   ) {}
 
   addCommentToPost = addCommentToPost;

--- a/src/post-comments/services/addCommentToPost.ts
+++ b/src/post-comments/services/addCommentToPost.ts
@@ -13,7 +13,7 @@ export default async function addCommentToPost(
     const PostCommentsModel = this.PostCommentsModel as Model<PostsComments>;
     const PostsService = this.PostsService as PostsService;
 
-    const session = await createTransactionSession();
+    const session = await createTransactionSession.bind(this)();
 
     const newComment = new PostComment();
     newComment.commenterId = userId;


### PR DESCRIPTION
inject `Connection` model of `mongoose` to `PostsCommentsService` class
for its methods being able to access the instance of `Connection` (database
connection).

Bind the `this` object of `addCommentToPost` method with `createTransactionSession`
function for `createTransactionSession` being able to access the instance of the
database connection model that has injected to `PostsCommentsService` class
(which is the owner of `addCommentToPost` method and that provides the `this`
object that contains the database connection model for `addCommentToPost`
method).