### PR TITLE
Reshape upvotes and downvotes fields in responses to carry only the total votes number

### DIFF
--- a/src/post-comments/dto/comment.type.ts
+++ b/src/post-comments/dto/comment.type.ts
@@ -1,7 +1,6 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { Types } from 'mongoose';
 import { MongoObjectIdScalar } from '../../global/dto/mongoObjectId.scalar';
-import { VoteType } from '../../global/dto/vote.type';
 
 @ObjectType()
 export class PostComment {
@@ -14,9 +13,9 @@ export class PostComment {
   @Field()
   comment: string;
 
-  @Field(() => VoteType)
-  upvotes: VoteType;
+  @Field(() => Int)
+  upvotes: number;
 
-  @Field(() => VoteType)
-  downvotes: VoteType;
+  @Field(() => Int)
+  downvotes: number;
 }

--- a/src/post-comments/services/getPostComments.ts
+++ b/src/post-comments/services/getPostComments.ts
@@ -18,7 +18,20 @@ export default async function getPostComments(
       {
         $project: {
           _id: false,
-          comments: { $slice: ['$comments', skip, limit] },
+          comments: {
+            $map: {
+              input: { $slice: ['$comments', skip, limit] },
+              as: 'comment',
+              in: {
+                id: '$$comment.id',
+                comment: '$$comment.comment',
+                commenterId: '$$comment.commenterId',
+                createdAt: '$$comment.createdAt',
+                upvotes: '$$comment.upvotes.totalVotes',
+                downvotes: '$$comment.downvotes.totalVotes',
+              },
+            },
+          },
           isThereMore: {
             $eq: [
               {

--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -5,6 +5,7 @@ import {
   Args,
   ResolveField,
   Parent,
+  Int,
 } from '@nestjs/graphql';
 import { PostsService } from './posts.service';
 import { Post } from './dto/post-data.type';
@@ -119,5 +120,15 @@ export class PostsResolver {
     }
 
     return null;
+  }
+
+  @ResolveField(() => Int, { name: 'upvotes', defaultValue: 0 })
+  async getPostUpvotesCount(@Parent() post: Post) {
+    return post.upvotes.totalVotes;
+  }
+
+  @ResolveField(() => Int, { name: 'downvotes', defaultValue: 0 })
+  async getPostDownvotesCount(@Parent() post: Post) {
+    return post.upvotes.totalVotes;
   }
 }


### PR DESCRIPTION
- Create `getPostUpvotesCount` & `getPostDownvotesCount` field resolvers
in `PostsResolver` class to reshape `upvotes` and `downvotes` fields of `Post`
object type to return only the total votes to the client.

- Add `$map` operation to the query that aggregates posts comments
in `getPostComments` function ti reshape the comments to make `upvotes`
and `downvotes` fields carry just the total votes.

- Convert the types `upvotes & downvotes` fields of `PostComment` class
to number for returning only the total votes to the client and hiding `voters`
field.