### PR TITLE
Add `createdAt` field to `PostComment` object type

### DIFF
--- a/src/post-comments/dto/comment.type.ts
+++ b/src/post-comments/dto/comment.type.ts
@@ -1,4 +1,4 @@
-import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { Field, GraphQLTimestamp, Int, ObjectType } from '@nestjs/graphql';
 import { Types } from 'mongoose';
 import { MongoObjectIdScalar } from '../../global/dto/mongoObjectId.scalar';
 
@@ -12,6 +12,9 @@ export class PostComment {
 
   @Field()
   comment: string;
+
+  @Field(() => GraphQLTimestamp, { nullable: true })
+  createdAt: Date;
 
   @Field(() => Int)
   upvotes: number;

--- a/src/post-comments/schemas/posts-comments.schema.ts
+++ b/src/post-comments/schemas/posts-comments.schema.ts
@@ -2,7 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Types } from 'mongoose';
 import { VotesSchema } from '../../global/schemas/vote.schema';
 
-@Schema({ versionKey: false, _id: false, timestamps: true })
+@Schema({ versionKey: false, _id: false, timestamps: { updatedAt: false } })
 export class PostComment {
   @Prop({ type: Types.ObjectId, required: true })
   id: Types.ObjectId;


### PR DESCRIPTION
- Add createdAt field to PostComment object type.

- Edit `PostComment` schema options and set `timestamps` option to
`{ updatedAt: false }` to exclude `updatedAt` field and include only
`createdAt` field by default.