### PR TITLE
Use the right property to get the total downvotes of the posts

### DIFF
--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -129,6 +129,6 @@ export class PostsResolver {
 
   @ResolveField(() => Int, { name: 'downvotes', defaultValue: 0 })
   async getPostDownvotesCount(@Parent() post: Post) {
-    return post.upvotes.totalVotes;
+    return post.downvotes.totalVotes;
   }
 }


### PR DESCRIPTION
Use `downvotes` property of `post` object instead of `upvotes` property in `getPostDownvotesCount` field resolver method of `PostsResolver` class to get the total downvotes of the posts.