### PR TITLE
Fix type safety errors in `createResourcesUpdateQuery.ts` and `createTagsUpdateQuery.ts` files

### DIFF
--- a/src/posts/services/createResourcesUpdateQuery.ts
+++ b/src/posts/services/createResourcesUpdateQuery.ts
@@ -4,7 +4,11 @@ import { EditPostOptions } from '../dto/update-post.input';
 export default function createResourcesUpdateQuery(
   updateResources: EditPostOptions['resources'],
 ) {
-  const resourcesUpdate = { $concatArrays: [] },
+  const resourcesUpdate: {
+      $concatArrays: (object | string)[];
+    } = {
+      $concatArrays: [],
+    },
     {
       newResources = [],
       removedResources = [],

--- a/src/posts/services/createTagsUpdateQuery.ts
+++ b/src/posts/services/createTagsUpdateQuery.ts
@@ -3,7 +3,9 @@ import { EditPostOptions } from '../dto/update-post.input';
 export default function createTagsUpdateQuery(
   updateTags: EditPostOptions['tags'],
 ) {
-  const tagsUpdates = { $concatArrays: [] },
+  const tagsUpdates: {
+      $concatArrays: (object | string)[];
+    } = { $concatArrays: [] },
     { newTags = [], removedTags = [] } = updateTags || {};
 
   if (newTags.length || removedTags.length) {


### PR DESCRIPTION
Add type to `resourcesUpdate` variable in `createResourcesUpdateQuery.ts` file and to `tagsUpdates` variable in `createTagsUpdateQuery.ts` file for avoiding type safety errors.