### PR TITLE
Add `id` field to `PostThumbnailInterface` interface type

### DIFF
--- a/src/posts/dto/create-post.input.ts
+++ b/src/posts/dto/create-post.input.ts
@@ -4,6 +4,9 @@ import { PostResourceInterface, PostThumbnailInterface } from '../interfaces';
 @InputType()
 class CreatePostThumbnail implements PostThumbnailInterface {
   @Field()
+  id: string;
+
+  @Field()
   src: string;
 }
 

--- a/src/posts/dto/post-data.type.ts
+++ b/src/posts/dto/post-data.type.ts
@@ -6,6 +6,7 @@ import { VoteType } from '../../global/dto/vote.type';
 
 @ObjectType({ implements: () => [PostThumbnailInterface] })
 class PostThumbnail implements PostThumbnailInterface {
+  id: string;
   src: string;
 }
 

--- a/src/posts/dto/update-post.input.ts
+++ b/src/posts/dto/update-post.input.ts
@@ -7,6 +7,9 @@ import { CreatePostPostResource } from './create-post.input';
 @InputType()
 class EditPostThumbnail implements PostThumbnailInterface {
   @Field()
+  id: string;
+
+  @Field()
   src: string;
 }
 

--- a/src/posts/interfaces.ts
+++ b/src/posts/interfaces.ts
@@ -3,6 +3,9 @@ import { Field, InterfaceType } from '@nestjs/graphql';
 @InterfaceType()
 export abstract class PostThumbnailInterface {
   @Field()
+  id: string;
+
+  @Field()
   src: string;
 }
 

--- a/src/posts/schemas/post.schema.ts
+++ b/src/posts/schemas/post.schema.ts
@@ -6,6 +6,9 @@ import { VotesSchema } from '../../global/schemas/vote.schema';
 @Schema({ versionKey: false, _id: false })
 class Thumbnail implements PostThumbnailInterface {
   @Prop({ required: true })
+  id: string;
+
+  @Prop({ required: true })
   src: string;
 }
 

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -66,14 +66,17 @@ interface VoteInterface {
 }
 
 type PostThumbnail implements PostThumbnailInterface {
+  id: String!
   src: String!
 }
 
 interface PostThumbnailInterface {
+  id: String!
   src: String!
 }
 
 type PostResource implements PostThumbnailInterface {
+  id: String!
   src: String!
   title: String!
   type: String!
@@ -216,6 +219,7 @@ input CreatePostInput {
 }
 
 input CreatePostThumbnail {
+  id: String!
   src: String!
 }
 
@@ -240,6 +244,7 @@ input EditPostOptions {
 }
 
 input EditPostThumbnail {
+  id: String!
   src: String!
 }
 


### PR DESCRIPTION
Add `id` field to `PostThumbnailInterface` interface type and add it to all classes that implement 
`PostThumbnailInterface` interface type.