### PR TITLE
Decrement post's comments count value after comment deletion

### DIFF
--- a/src/post-comments/services/removeCommentFromPost.ts
+++ b/src/post-comments/services/removeCommentFromPost.ts
@@ -1,6 +1,8 @@
 import { Model, Types } from 'mongoose';
 import { PostsComments } from '../schemas/posts-comments.schema';
 import { InternalServerErrorException } from '@nestjs/common';
+import createTransactionSession from '../../global/utils/createTransactionSession';
+import { PostsService } from '../../posts/posts.service';
 
 export default async function removeCommentFromPost(
   postId: Types.ObjectId,
@@ -8,14 +10,35 @@ export default async function removeCommentFromPost(
   userId: Types.ObjectId,
 ) {
   try {
+    const session = await createTransactionSession.bind(this)();
+
     const PostCommentsModel = this.PostCommentsModel as Model<PostsComments>;
+    const PostsService = this.PostsService as PostsService;
 
     const { acknowledged, modifiedCount } = await PostCommentsModel.updateOne(
       { _id: postId },
-      { $pull: { comments: { id: commentId, commenterId: userId } } },
+      {
+        $pull: {
+          comments: {
+            id: commentId,
+            commenterId: userId,
+          },
+        },
+      },
+      { session },
     );
 
-    return acknowledged && !!modifiedCount;
+    if (
+      acknowledged &&
+      modifiedCount &&
+      (await PostsService.incrementPostCommentsCount(postId, session, true))
+    ) {
+      return await session.commitTransaction().then(() => true);
+    } else {
+      await session.abortTransaction();
+    }
+
+    return false;
   } catch {
     throw new InternalServerErrorException();
   }


### PR DESCRIPTION
Use `incrementPostCommentsCount` method of `PostsService` class to decrement post comments count value 
after removing a comment from the post.

Use `createTransactionSession` function to create a transaction session to handle updating `posts` and 
`postscomments` collections together so that all success or failed together.