### PR TITLE
Fix typo in comments pagination response type

### DIFF
--- a/src/post-comments/dto/comments-pagination-response.type.ts
+++ b/src/post-comments/dto/comments-pagination-response.type.ts
@@ -4,7 +4,7 @@ import { PostComment } from './comment.type';
 @ObjectType()
 export class PostCommentsPaginationResponse {
   @Field()
-  isThereMore: boolean;
+  areThereMore: boolean;
 
   @Field(() => [PostComment])
   comments: PostComment[];

--- a/src/post-comments/services/getPostComments.ts
+++ b/src/post-comments/services/getPostComments.ts
@@ -63,7 +63,7 @@ export default async function getPostComments(
               },
             },
           ],
-          isThereMoreCommentsPipeline: [
+          areThereMoreCommentsPipeline: [
             { $match: { _id: postId } },
             {
               $project: {
@@ -85,10 +85,10 @@ export default async function getPostComments(
       },
       {
         $project: {
-          isThereMore: {
+          areThereMore: {
             $getField: {
               field: 'answer',
-              input: { $arrayElemAt: ['$isThereMoreCommentsPipeline', 0] },
+              input: { $arrayElemAt: ['$areThereMoreCommentsPipeline', 0] },
             },
           },
           comments: '$commentsPipeline',
@@ -101,7 +101,7 @@ export default async function getPostComments(
     }
     return {
       comments: [],
-      isThereMore: false,
+      areThereMore: false,
     };
   } catch {
     throw new InternalServerErrorException();

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -137,17 +137,25 @@ type JWT {
   accessToken: String!
 }
 
+type CommentOwner {
+  firstName: String!
+  lastName: String!
+  headline: String!
+  avatar: String
+}
+
 type PostComment {
   id: MongoObjectId!
   commenterId: MongoObjectId!
   comment: String!
   createdAt: Timestamp
+  owner: CommentOwner!
   upvotes: Int!
   downvotes: Int!
 }
 
 type PostCommentsPaginationResponse {
-  isThereMore: Boolean!
+  areThereMore: Boolean!
   comments: [PostComment!]!
 }
 
@@ -188,7 +196,6 @@ type Mutation {
   upvotePost(postId: MongoObjectId!): Boolean!
   downvotePost(postId: MongoObjectId!): Boolean!
   bookmarkPost(postId: MongoObjectId!): Boolean!
-  unbookmarkPost(postId: MongoObjectId!): Boolean!
   logInUser(logInUserInput: LogInUserInput!): JWT
   signUpUser(signUpUserInput: SignUpUserInput!): JWT
   addCommentToPost(postId: MongoObjectId!, comment: String!): String!


### PR DESCRIPTION
- Rename `isThereMore` field of `PostCommentsPaginationResponse` to
`areThereMore`.

- Rename `isThereMore` fields of mongodb query and response object
in `getPostComments.ts` file.**