### PR TITLE
Change all user's avatar fields types to a new type

### DIFF
--- a/src/auth/dto/sign-up-user.input.ts
+++ b/src/auth/dto/sign-up-user.input.ts
@@ -1,12 +1,25 @@
 import { InputType, Field } from '@nestjs/graphql';
+import { UserAvatarInterface } from '../../users/interfaces';
+
+@InputType()
+export abstract class AvatarInput implements UserAvatarInterface {
+  @Field()
+  id: string;
+
+  @Field()
+  src: string;
+}
 
 @InputType()
 export class SignUpUserInput {
-  @Field({ description: 'The firs name of the user' })
+  @Field({ description: 'The first name of the user' })
   firstName: string;
 
   @Field({ description: 'The last name of the user' })
   lastName: string;
+
+  @Field({ description: 'The headline of the user', nullable: true })
+  avatar?: AvatarInput;
 
   @Field({ description: 'The headline of the user' })
   headline: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,10 @@
+import { Field, InterfaceType } from '@nestjs/graphql';
+
+@InterfaceType()
+export abstract class ImageInterface {
+  @Field()
+  id: string;
+
+  @Field()
+  src: string;
+}

--- a/src/post-comments/dto/comment.type.ts
+++ b/src/post-comments/dto/comment.type.ts
@@ -1,6 +1,7 @@
 import { Field, GraphQLTimestamp, Int, ObjectType } from '@nestjs/graphql';
 import { Types } from 'mongoose';
 import { MongoObjectIdScalar } from '../../global/dto/mongoObjectId.scalar';
+import { UserAvatar } from '../../users/dto/user-data.type';
 
 @ObjectType()
 export class CommentOwner {
@@ -14,7 +15,7 @@ export class CommentOwner {
   headline: string;
 
   @Field({ nullable: true })
-  avatar: string;
+  avatar: UserAvatar;
 }
 
 @ObjectType()

--- a/src/posts/interfaces.ts
+++ b/src/posts/interfaces.ts
@@ -1,7 +1,8 @@
 import { Field, InterfaceType } from '@nestjs/graphql';
+import { ImageInterface } from '../interfaces';
 
 @InterfaceType()
-export abstract class PostThumbnailInterface {
+export abstract class PostThumbnailInterface extends ImageInterface {
   @Field()
   id: string;
 

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -2,6 +2,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type UserAvatar {
+  id: String!
+  src: String!
+}
+
 type User {
   """
   The ID of the user
@@ -26,7 +31,7 @@ type User {
   """
   The profile picture of the user
   """
-  avatar: String
+  avatar: UserAvatar
 
   """
   The email of the user
@@ -141,7 +146,7 @@ type CommentOwner {
   firstName: String!
   lastName: String!
   headline: String!
-  avatar: String
+  avatar: UserAvatar
 }
 
 type PostComment {
@@ -214,7 +219,12 @@ input UpdateUserDataInput {
   firstName: String
   lastName: String
   headline: String
-  avatar: String
+  avatar: UpdateAvatarInput
+}
+
+input UpdateAvatarInput {
+  id: String
+  src: String
 }
 
 input CreatePostInput {
@@ -281,7 +291,7 @@ input LogInUserInput {
 
 input SignUpUserInput {
   """
-  The firs name of the user
+  The first name of the user
   """
   firstName: String!
 
@@ -289,6 +299,11 @@ input SignUpUserInput {
   The last name of the user
   """
   lastName: String!
+
+  """
+  The headline of the user
+  """
+  avatar: AvatarInput
 
   """
   The headline of the user
@@ -304,4 +319,9 @@ input SignUpUserInput {
   The password of the user
   """
   password: String!
+}
+
+input AvatarInput {
+  id: String!
+  src: String!
 }

--- a/src/users/dto/update-data-user.input.ts
+++ b/src/users/dto/update-data-user.input.ts
@@ -1,4 +1,14 @@
 import { InputType, Field } from '@nestjs/graphql';
+import { UserAvatarInterface } from '../interfaces';
+
+@InputType()
+export abstract class UpdateAvatarInput implements UserAvatarInterface {
+  @Field({ nullable: true })
+  id: string;
+
+  @Field({ nullable: true })
+  src: string;
+}
 
 @InputType()
 export class UpdateUserDataInput {
@@ -12,5 +22,5 @@ export class UpdateUserDataInput {
   headline?: string;
 
   @Field({ nullable: true })
-  avatar?: string;
+  avatar?: UpdateAvatarInput;
 }

--- a/src/users/dto/user-data.type.ts
+++ b/src/users/dto/user-data.type.ts
@@ -2,6 +2,16 @@ import { ObjectType, Field } from '@nestjs/graphql';
 import { MongoObjectIdScalar } from '../../global/dto/mongoObjectId.scalar';
 import { Types } from 'mongoose';
 import { roles } from '../../constants/users-roles';
+import { UserAvatarInterface } from '../interfaces';
+
+@ObjectType()
+export abstract class UserAvatar implements UserAvatarInterface {
+  @Field()
+  id: string;
+
+  @Field()
+  src: string;
+}
 
 @ObjectType()
 export class User {
@@ -17,11 +27,11 @@ export class User {
   @Field({ description: 'The headline of the user' })
   headline: string;
 
-  @Field({
+  @Field(() => UserAvatar, {
     description: 'The profile picture of the user',
     nullable: true,
   })
-  avatar: string;
+  avatar: UserAvatar;
 
   @Field({ description: 'The email of the user' })
   email: string;

--- a/src/users/interfaces.ts
+++ b/src/users/interfaces.ts
@@ -1,0 +1,11 @@
+import { Field, InterfaceType } from '@nestjs/graphql';
+import { ImageInterface } from '../interfaces';
+
+@InterfaceType()
+export abstract class UserAvatarInterface extends ImageInterface {
+  @Field()
+  id: string;
+
+  @Field()
+  src: string;
+}

--- a/src/users/schemas/user-avatar.schema.ts
+++ b/src/users/schemas/user-avatar.schema.ts
@@ -1,0 +1,11 @@
+import { Prop, Schema } from '@nestjs/mongoose';
+import { UserAvatarInterface } from '../interfaces';
+
+@Schema({ versionKey: false, _id: false })
+export abstract class AvatarSchema implements UserAvatarInterface {
+  @Prop({ required: true })
+  id: string;
+
+  @Prop({ required: true })
+  src: string;
+}

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -1,6 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Types, HydratedDocument } from 'mongoose';
 import { roles } from '../../constants/users-roles';
+import { AvatarSchema } from './user-avatar.schema';
 
 @Schema({ versionKey: false })
 export class User {
@@ -19,8 +20,8 @@ export class User {
   @Prop({ required: true })
   password: string;
 
-  @Prop()
-  avatar: string;
+  @Prop({ type: AvatarSchema })
+  avatar: AvatarSchema;
 
   @Prop({ default: roles.USER, required: true })
   role: string;


### PR DESCRIPTION
- Create `src/interfaces.ts` file and create `ImageInterface` interface type
inside it.

- Create `UserAvatarInterface` interface type in `src/users/interfaces.ts`
file for all user avatar related types; (`UserAvatarInterface` interface
type inherits `ImageInterface` interface).

- Make `PostThumbnailInterface` interface type inherits `ImageInterface`
 interface.


- Add avatar field to SignUpUserInput input type.

- Create `UserAvatar` object type in `src/users/dto/user-data.type.ts` file
and convert the type of `avatar` field of `User` object type in this file to
`UserAvatar`.

- Use `UserAvatar` from `src/users/dto/user-data.type.ts` file as the type
of `avatar` field of `CommentOwner` object type in
`src/post-comments/dto/comment.type.ts` file.

- Create `UpdateAvatarInput` object type and set it as type of `avatar` filed
of `UpdateUserDataInput` class in `src/users/dto/update-data-user.input.ts`
file.

- Create `src/users/schemas/user-avatar.schema.ts` file and define inside
it `AvatarSchema` schema type and import it to use it as type of `avatar`
field of `User` schema in `src/users/schemas/user.schema.ts` file.