### PR TITLE
Return `null` if user is unauthorized in `userVote` field resolver

### DIFF
--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -103,6 +103,10 @@ export class PostsResolver {
 
   @ResolveField(() => String, { name: 'userVote', nullable: true })
   async userVote(@CurrentUser() user: AuthorizedUser, @Parent() post: Post) {
+    if (!user) {
+      return null;
+    }
+
     if (post.upvotes.voters.some((voterId) => user.id.equals(voterId))) {
       return 'upvote';
     }


### PR DESCRIPTION
Return `null` if the user is unauthorized in `userVote` field resolver method because `user` argument will be undefined if the user is unauthorized.