### PR TITLE
Create users roles guards

### DIFF
--- a/src/auth/decorators/is-public.decorator.ts
+++ b/src/auth/decorators/is-public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'public';
+export const IsPublic = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -2,12 +2,41 @@ import { ExecutionContext, Injectable } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { AuthGuard } from '@nestjs/passport';
 import { createParamDecorator } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../decorators/is-public.decorator';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class GqlJwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
   getRequest(context: ExecutionContext) {
     const ctx = GqlExecutionContext.create(context);
     return ctx.getContext().req;
+  }
+
+  handleRequest<TUser>(
+    ...parapeters: [any, any, any, ExecutionContext, any]
+  ): TUser {
+    try {
+      return super.handleRequest<TUser>(...parapeters);
+    } catch {
+      return null as TUser;
+    }
+  }
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    const result = super.canActivate(context);
+    return isPublic || result;
   }
 }
 

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,42 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { roles, RolesType } from '../../constants/users-roles';
+
+export const Public = Reflector.createDecorator<boolean>();
+
+@Injectable()
+export class OnlyUsersGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+  canActivate(context: ExecutionContext) {
+    return canActivate.bind(this)(context, roles.USER);
+  }
+}
+
+@Injectable()
+export class OnlyAdminsGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+  canActivate(context: ExecutionContext) {
+    return canActivate(context, roles.USER);
+  }
+}
+
+function canActivate(context: ExecutionContext, role: RolesType): boolean {
+  const isPublic = this.reflector.get(Public, context.getHandler());
+  if (isPublic) {
+    return true;
+  }
+
+  const { req } = context.switchToHttp().getNext();
+  if (role === req?.user?.role) {
+    return true;
+  } else {
+    throw new UnauthorizedException(
+      'You are not authorized to access this route',
+    );
+  }
+}

--- a/src/constants/users-roles.ts
+++ b/src/constants/users-roles.ts
@@ -1,3 +1,5 @@
+export type RolesType = 'admin' | 'user';
+
 export const roles: { USER: 'user'; ADMIN: 'admin' } = Object.create(
   {},
   {


### PR DESCRIPTION
Define and export users roles types in `src/constants/users-roles.ts`
file.

Create `src/auth/guards/roles.guard.ts` file and create in this file
`OnlyUsersGuard` guard that allows only users to access the resource
and `OnlyAdminsGuard` guard that allows only admins to access the
resource.

Create `IsPublic` metadata setter for marking resources as public.

Add additional logic to `GqlJwtAuthGuard` auth guard class's
`handleRequest` and `canActivate` methods.

- Prevent `handleRequest` method from throwing an error if the
request is unauthenticated and make it just returns `null` for
delegating handling authorization process to the next method
in request handling queue (which is `canActivate`).

- Make `canActivate` method checks if the resource is decorated
as public or not before applying the actual user role check process.
