### PR TITLE
Move `CurrentUser` param decorator to a separated file

### DIFF
--- a/src/auth/decorators/current-user.decoretor.ts
+++ b/src/auth/decorators/current-user.decoretor.ts
@@ -1,0 +1,12 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { JWTPayload } from '../dto/auth-related.dto';
+
+export const CurrentUser = createParamDecorator(
+  (field: keyof JWTPayload, context: ExecutionContext) => {
+    const ctx = GqlExecutionContext.create(context);
+    const { user } = ctx.getContext().req;
+
+    return field ? user?.[field] : user;
+  },
+);

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,7 +1,6 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { AuthGuard } from '@nestjs/passport';
-import { createParamDecorator } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { IS_PUBLIC_KEY } from '../decorators/is-public.decorator';
 import { Observable } from 'rxjs';
@@ -39,10 +38,3 @@ export class GqlJwtAuthGuard extends AuthGuard('jwt') {
     return isPublic || result;
   }
 }
-
-export const CurrentUser = createParamDecorator(
-  (_data: unknown, context: ExecutionContext) => {
-    const ctx = GqlExecutionContext.create(context);
-    return ctx.getContext().req.user;
-  },
-);

--- a/src/post-comments/posts-comments.resolver.ts
+++ b/src/post-comments/posts-comments.resolver.ts
@@ -1,4 +1,4 @@
-import { CurrentUser, GqlJwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GqlJwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
 import { Types } from 'mongoose';
 import { BadRequestException, UseGuards } from '@nestjs/common';
@@ -8,6 +8,7 @@ import { PostsCommentsService } from './posts-comments.service';
 import { PostsComments } from './schemas/posts-comments.schema';
 import { PaginationOptions } from '../global/dto/pagination-options.dto';
 import { PostCommentsPaginationResponse } from './dto/comments-pagination-response.type';
+import { CurrentUser } from '../auth/decorators/current-user.decoretor';
 
 @Resolver(() => PostsComments)
 @UseGuards(GqlJwtAuthGuard)

--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -18,9 +18,10 @@ import { PaginationOptions } from '../global/dto/pagination-options.dto';
 import { Types } from 'mongoose';
 import { MongoObjectIdScalar } from '../global/dto/mongoObjectId.scalar';
 import { UseGuards } from '@nestjs/common';
-import { CurrentUser, GqlJwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GqlJwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthorizedUser } from '../auth/dto/auth-related.dto';
 import { UserFeedsPaginationResponse } from './dto/user-feeds-pagination-response.type';
+import { CurrentUser } from '../auth/decorators/current-user.decoretor';
 
 @Resolver(() => Post)
 @UseGuards(GqlJwtAuthGuard)

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -17,9 +17,10 @@ import { PaginationOptions } from '../global/dto/pagination-options.dto';
 import { MongoObjectIdScalar } from '../global/dto/mongoObjectId.scalar';
 import { Types } from 'mongoose';
 import { UseGuards } from '@nestjs/common';
-import { CurrentUser, GqlJwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GqlJwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthorizedUser } from '../auth/dto/auth-related.dto';
 import { UserBookmarksPaginationResponse } from './dto/user-bookmarks-pagination-response.type';
+import { CurrentUser } from '../auth/decorators/current-user.decoretor';
 
 @Resolver(() => User)
 @UseGuards(GqlJwtAuthGuard)


### PR DESCRIPTION
Create `src/auth/decorators/current-user.decoretor.ts` file and move
`CurrentUser` param decorator to it from `src/auth/guards/jwt-auth.guard.ts`
file.

Reimport `CurrentUser` param decorator from the new file in
`posts-comments.resolver.ts`, `posts.resolver.ts` and
`users.resolver.ts` files.