### PR TITLE
Fix "cannot read properties of null" error in `userFeeds` query handler method

### DIFF
--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -124,7 +124,7 @@ export class PostsResolver {
     @Args('paginationOptions') paginationOptions: PaginationOptions,
     @CurrentUser() user: AuthorizedUser,
   ) {
-    return this.postsService.getUserFeeds(user.id, paginationOptions);
+    return this.postsService.getUserFeeds(user?.id, paginationOptions);
   }
 
   @ResolveField(() => Int, { name: 'upvotes', defaultValue: 0 })


### PR DESCRIPTION
Use the optional chaining operator to avoid the "cannot read properties of null" error in `userFeeds` query handler method of `PostsResolver` class when trying to access authorized user id while user is unauthorized and `user` variable is `null`.