### PR TITLE
Mark some queries as public queries can any user access them

### DIFF
--- a/src/post-comments/posts-comments.resolver.ts
+++ b/src/post-comments/posts-comments.resolver.ts
@@ -8,6 +8,7 @@ import { PostsCommentsService } from './posts-comments.service';
 import { PostsComments } from './schemas/posts-comments.schema';
 import { PaginationOptions } from '../global/dto/pagination-options.dto';
 import { PostCommentsPaginationResponse } from './dto/comments-pagination-response.type';
+import { IsPublic } from '../auth/decorators/is-public.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decoretor';
 
 @Resolver(() => PostsComments)
@@ -43,6 +44,7 @@ export class PostsCommentsResolver {
   }
 
   @Query(() => PostCommentsPaginationResponse)
+  @IsPublic()
   async getPostComments(
     @Args('postId', { type: () => MongoObjectIdScalar }) postId: Types.ObjectId,
     @Args('paginationOptions') paginationOptions: PaginationOptions,

--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -22,6 +22,7 @@ import { GqlJwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthorizedUser } from '../auth/dto/auth-related.dto';
 import { UserFeedsPaginationResponse } from './dto/user-feeds-pagination-response.type';
 import { CurrentUser } from '../auth/decorators/current-user.decoretor';
+import { IsPublic } from '../auth/decorators/is-public.decorator';
 
 @Resolver(() => Post)
 @UseGuards(GqlJwtAuthGuard)
@@ -40,6 +41,7 @@ export class PostsResolver {
   }
 
   @Query(() => [Post], { name: 'posts' })
+  @IsPublic()
   async findPosts(
     @Args('searchQuery') searchQuery: SearchForPostInput,
     @Args('options', { nullable: true }) options: PaginationOptions,
@@ -48,6 +50,7 @@ export class PostsResolver {
   }
 
   @Query(() => Post, { name: 'post', nullable: true })
+  @IsPublic()
   async findPostById(
     @Args('postId', { type: () => MongoObjectIdScalar }) postId: Types.ObjectId,
   ) {
@@ -121,6 +124,7 @@ export class PostsResolver {
   }
 
   @Query(() => UserFeedsPaginationResponse, { name: 'userFeeds' })
+  @IsPublic()
   async userFeeds(
     @Args('paginationOptions') paginationOptions: PaginationOptions,
     @CurrentUser() user: AuthorizedUser,


### PR DESCRIPTION
Mark `findPosts`, `findPostById` and `userFeeds` queries of
`PostsResolver` class as public queries by `IsPublic` decorator
function so that any user can access them.

Nark `getPostComments` query of `PostsCommentsResolver`
class as public query using the decorator function `IsPublic`