### PR TITLE
Handle including testing environment variables to testing processes

### DIFF
--- a/scripts/execute.mjs
+++ b/scripts/execute.mjs
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
 
-export default function execute(command) {
-  execSync(command, { stdio: 'inherit' });
+export default function execute(command, env) {
+  execSync(command, { stdio: 'inherit', env });
 };

--- a/scripts/getTestingENV.mjs
+++ b/scripts/getTestingENV.mjs
@@ -1,0 +1,12 @@
+import { readFileSync } from "fs";
+
+export default function getTestingENV() {
+    const envText = readFileSync(".env.test.local", { encoding: "utf-8" })
+    const env = {}
+    envText.split("\n").forEach((line) => {
+        const [name, value] = line.split("=")
+        Object.assign(env, { [name]: value })
+    })
+
+    return env
+};

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,18 +1,21 @@
 import { argv } from 'process';
 import execute from './execute.mjs';
 import initializeMongodbReplSet from './initializeMongodbReplSet.mjs';
+import getTestingENV from './getTestingENV.mjs';
 
 const target = argv[2] || "all";
 
+const envVariables = getTestingENV();
+
 if (target === "units") {
-    execute('yarn test:units');
+    execute('yarn test:units', envVariables);
     process.exit();
 } else {
     execute('docker-compose -f docker-compose-testing-mongodb.yaml up -d');
 
     initializeMongodbReplSet()
         .then(() => {
-            execute(`yarn test:${target}`);
+            execute(`yarn test:${target}`, envVariables);
             process.exit();
         })
 }


### PR DESCRIPTION
- Add `env` parameter to `scripts/execute.mjs` function which
is an object of environment variables for assigning it as option
to `execSync` function of `child_process` module.

- Create `getTestingENV` function, The function reads and parses
the environment variables from `.env.test.local` file and returns
them as an object.

- Use `getTestingENV` function to get testing environment variables
and pass them to `execute` function (the function that executes or
runs test commands) as the second parameter.