### PR TITLE
Fix "cannot read id property of null" error in `users.resolver.ts` file

### DIFF
--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -32,7 +32,7 @@ export class UsersResolver {
 
   @Query(() => User, { name: 'userData', nullable: true })
   async getUserData(@CurrentUser() user: AuthorizedUser) {
-    return await this.usersService.findUserById(user.id);
+    return await this.usersService.findUserById(user?.id);
   }
 
   @Query(() => User, { name: 'user', nullable: true })


### PR DESCRIPTION
Use the optional chaining operation to avoid "cannot read id property of null" error in `src/users/users.resolver.ts` file at `getUserData` query handler method.